### PR TITLE
Adds uncertainty fields only when requested

### DIFF
--- a/R/GetInformation.R
+++ b/R/GetInformation.R
@@ -230,6 +230,11 @@ get_datasources <- function(save_file = FALSE, ...) {
 #' of these arguments should be the one from the column \code{Name} in
 #' the response from the \code{get_*} functions.
 #'
+#' By default, all results exclude columns related to the uncertainty
+#' of the values requested (StandardErrorValue, ConfidenceInterval, etc...).
+#' By setting the argument \code{includeUncertainty = TRUE}, the uncertainty
+#' fields will be included in the final data frame.
+#'
 #' Once the data is read from the API, some transformations are applied:
 #'
 #' \itemize{
@@ -324,7 +329,20 @@ get_recorddata <- function(save_file = FALSE, verbose = TRUE, ...) {
 
   ## # Currently includes some ID columns
   ## browser()
+
   res <- res[values_env$col_order]
+
+  uncertainty <- list(...)$includeUncertainty
+  if (isFALSE(uncertainty) || is.null(uncertainty)) {
+    uncertainty_cols <- c("HasUncertaintyRecord",
+                          "StandardErrorValue",
+                          "ConfidenceInterval",
+                          "ConfidenceIntervalLowerBound",
+                          "ConfidenceIntervalUpperBound")
+
+    res <- res[setdiff(names(res), uncertainty_cols)]
+  }
+
 
   res
 }

--- a/man/build_filter.Rd
+++ b/man/build_filter.Rd
@@ -27,6 +27,7 @@ build_filter(
   includeDependencies = NULL,
   includeFormerCountries = NULL,
   includeDataIDs = NULL,
+  includeUncertainty = NULL,
   years = NULL,
   verbose
 )

--- a/man/get_recorddata.Rd
+++ b/man/get_recorddata.Rd
@@ -34,6 +34,11 @@ arguments that have equivalent \code{get_*} functions. For example,
 of these arguments should be the one from the column \code{Name} in
 the response from the \code{get_*} functions.
 
+By default, all results exclude columns related to the uncertainty
+of the values requested (StandardErrorValue, ConfidenceInterval, etc...).
+By setting the argument \code{includeUncertainty = TRUE}, the uncertainty
+fields will be included in the final data frame.
+
 Once the data is read from the API, some transformations are applied:
 
 \itemize{
@@ -74,14 +79,15 @@ X <- get_recorddata(dataProcessTypeIds = 2,
 
 head(X)
 
-# Same thing but limited to DataSourceShortNames
+# Same thing but limited to DataSourceShortNames and including the uncertainty
 X <- get_recorddata(dataProcessTypeIds = 2,
                    indicatorTypeIds = 8,
                    locIds = 818,
                    locAreaTypeIds = 2,
                    subGroupIds = 2,
                    isComplete = 0,
-                   dataSourceShortNames = "OECD 1980")
+                   dataSourceShortNames = "OECD 1980",
+                   includeUncertainty = TRUE)
 
 head(X)
 

--- a/tests/testthat/test-API.R
+++ b/tests/testthat/test-API.R
@@ -89,7 +89,7 @@ test_that("get_iitypes can subset correctly", {
   # longer and longer.
 
   # Here I'm testing all argument combined. If they
-  # work, it should be the same  
+  # work, it should be the same
   x <- get_iitypes(componentIds = 4,
                    indicatorTypeIds = 38,
                    indicatorIds = 323)
@@ -332,4 +332,49 @@ test_that("isComplete is set to 'Total' by default", {
 
   # Both results are the same
   expect_identical(births, births_iscomplete)
+})
+
+test_that("get_recorddata grabs uncertainty columns when includeUncertainty = TRUE", {
+
+  uncertainty_cols <- c("HasUncertaintyRecord",
+                        "StandardErrorValue",
+                        "ConfidenceInterval",
+                        "ConfidenceIntervalLowerBound",
+                        "ConfidenceIntervalUpperBound")
+
+  X <- get_recorddata(dataProcessTypeIds = 2,
+                      indicatorTypeIds = 8,
+                      locIds = 818,
+                      locAreaTypeIds = 2,
+                      subGroupIds = 2,
+                      isComplete = 0)
+
+  # If includeUncertainty is NULL (default), the columns
+  # are NOT included.
+  expect_false(all(uncertainty_cols %in% names(X)))
+
+  X <- get_recorddata(dataProcessTypeIds = 2,
+                      indicatorTypeIds = 8,
+                      locIds = 818,
+                      locAreaTypeIds = 2,
+                      subGroupIds = 2,
+                      isComplete = 0,
+                      includeUncertainty = FALSE)
+
+  # If includeUncertainty is FALSE, the columns
+  # are NOT included.
+  expect_false(all(uncertainty_cols %in% names(X)))
+
+  X <- get_recorddata(dataProcessTypeIds = 2,
+                      indicatorTypeIds = 8,
+                      locIds = 818,
+                      locAreaTypeIds = 2,
+                      subGroupIds = 2,
+                      isComplete = 0,
+                      includeUncertainty = TRUE)
+
+  # If includeUncertainty is TRUE, the columns
+  # ARE included.
+  expect_true(all(uncertainty_cols %in% names(X)))
+
 })

--- a/vignettes/Downloading-UNPD-data-into-R.Rmd
+++ b/vignettes/Downloading-UNPD-data-into-R.Rmd
@@ -114,6 +114,7 @@ oman <- get_recorddata(dataProcessTypeIds = "Register",
 head(oman)
 ```
 
+By default, the results from `get_recorddata` exclude any uncertainty columns such as `StandardErrorValue`, `ConfidenceInterval`, etc. By setting `includeUncertainty = TRUE`, the resulting data frame adds new fields which have uncertainty for the requested values. These fields are all next to each other so by limiting the data to the fields next to `StandardErrorValue`, the user can quickly see the uncertainty columns.
 
 #### Change the IP of the UNPD SQL API
 


### PR DESCRIPTION
- Only return uncertainty columns when `includeUncertainty` is set to `TRUE`

- Adds examples and text in docs

- Adds text in vignette

- Adds tests